### PR TITLE
MAKE-1360: add field to parse gotest files

### DIFF
--- a/operations.go
+++ b/operations.go
@@ -281,8 +281,9 @@ func (c CmdResultsXunit) Resolve() *CommandDefinition {
 func xunitResultsFactory() Command { return CmdResultsXunit{} }
 
 type CmdResultsGoTest struct {
-	JSONFormat   bool `json:"-"`
-	LegacyFormat bool `json:"-"`
+	JSONFormat   bool     `json:"-"`
+	LegacyFormat bool     `json:"-"`
+	Files        []string `json:"files"`
 }
 
 func (c CmdResultsGoTest) Name() string { return "gotest.parse_json" }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1360

The command now lets you actually specify an input file for parsing go test results.