### PR TITLE
MAKE-1361: return correct name for gotest.parse_files command

### DIFF
--- a/operations.go
+++ b/operations.go
@@ -286,7 +286,12 @@ type CmdResultsGoTest struct {
 	Files        []string `json:"files"`
 }
 
-func (c CmdResultsGoTest) Name() string { return "gotest.parse_json" }
+func (c CmdResultsGoTest) Name() string {
+	if c.LegacyFormat {
+		return "gotest.parse_files"
+	}
+	return "gotest.parse_json"
+}
 func (c CmdResultsGoTest) Validate() error {
 	if c.JSONFormat == c.LegacyFormat {
 		return errors.New("invalid format for gotest operation")


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1361

For some reason, both `gotest.parse_json` and `gotest.parse_files` are multiplexed onto the same struct so we have to switch on the legacy boolean to determine which one it is.