### PR TITLE
EVG-19050: add more dependency/task fields and fix dependency variant bug

### DIFF
--- a/task.go
+++ b/task.go
@@ -17,7 +17,23 @@ type Task struct {
 
 type TaskDependency struct {
 	Name    string `json:"name" yaml:"name"`
-	Variant string `json:"variant" yaml:"variant"`
+	Variant string `json:"variant,omitempty" yaml:"variant,omitempty"`
+	Status  string `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+func (td *TaskDependency) SetName(name string) *TaskDependency {
+	td.Name = name
+	return td
+}
+
+func (td *TaskDependency) SetVariant(variant string) *TaskDependency {
+	td.Variant = variant
+	return td
+}
+
+func (td *TaskDependency) SetStatus(status string) *TaskDependency {
+	td.Status = status
+	return td
 }
 
 func (t *Task) Command(cmds ...Command) *Task {

--- a/task_test.go
+++ b/task_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 )
 
+var trueVal = true
+
 func TestTaskBuilder(t *testing.T) {
 	cases := map[string]func(t *testing.T, task *Task){
 		"DependencySetterNoop": func(t *testing.T, task *Task) {
@@ -13,10 +15,16 @@ func TestTaskBuilder(t *testing.T) {
 			assert(t, len(task.Dependencies) == 0, "not changed")
 		},
 		"DependencySetterOne": func(t *testing.T, task *Task) {
-			t2 := task.Dependency(TaskDependency{Name: "foo"})
+			t2 := task.Dependency(TaskDependency{
+				Name:    "foo",
+				Status:  "*",
+				Variant: "variant",
+			})
 			assert(t, task == t2, "chainable")
-			assert(t, len(task.Dependencies) == 1, "not changed")
+			require(t, len(task.Dependencies) == 1, "not changed")
 			assert(t, task.Dependencies[0].Name == "foo")
+			assert(t, task.Dependencies[0].Status == "*")
+			assert(t, task.Dependencies[0].Variant == "variant")
 		},
 		"DependencySetterDuplicate": func(t *testing.T, task *Task) {
 			t2 := task.Dependency(TaskDependency{Name: "foo"}).Dependency(
@@ -183,6 +191,27 @@ func TestTaskBuilder(t *testing.T) {
 			test(t, task)
 		})
 	}
+}
+
+func TestTaskDependency(t *testing.T) {
+	t.Run("NameSetter", func(t *testing.T) {
+		td := &TaskDependency{}
+		assert(t, td.Name == "")
+		td.SetName("name")
+		assert(t, td.Name == "name")
+	})
+	t.Run("VariantSetter", func(t *testing.T) {
+		td := &TaskDependency{}
+		assert(t, td.Variant == "")
+		td.SetVariant("variant")
+		assert(t, td.Variant == "variant")
+	})
+	t.Run("StatusSetter", func(t *testing.T) {
+		td := &TaskDependency{}
+		assert(t, td.Status == "")
+		td.SetStatus("failed")
+		assert(t, td.Status == "failed")
+	})
 }
 
 func TestTaskGroup(t *testing.T) {

--- a/variant.go
+++ b/variant.go
@@ -11,7 +11,7 @@ type Variant struct {
 	Expansions       map[string]interface{}  `json:"expansions,omitempty" yaml:"expansions,omitempty"`
 	DisplayTaskSpecs []DisplayTaskDefinition `json:"display_tasks,omitempty" yaml:"display_tasks,omitempty"`
 	// If Activate is set to false, then we don't initially activate the build variant.
-	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
+	Activate *bool `json:"activate" yaml:"activate,omitempty"`
 }
 
 type DisplayTaskDefinition struct {

--- a/variant.go
+++ b/variant.go
@@ -32,8 +32,8 @@ func (ts *TaskSpec) SetStepback(shouldStepback bool) *TaskSpec {
 	return ts
 }
 func (ts *TaskSpec) SetDistros(distros []string) *TaskSpec { ts.Distro = distros; return ts }
-func (ts *TaskSpec) SetActivate(shouldActivate bool) *TaskSpec {
-	ts.Activate = &shouldActivate
+func (ts *TaskSpec) SetActivate(shouldActivate *bool) *TaskSpec {
+	ts.Activate = shouldActivate
 	return ts
 }
 

--- a/variant.go
+++ b/variant.go
@@ -23,6 +23,18 @@ type TaskSpec struct {
 	Name     string   `json:"name" yaml:"name"`
 	Stepback bool     `json:"stepback,omitempty" yaml:"stepback,omitempty"`
 	Distro   []string `json:"distros,omitempty" yaml:"distro,omitempty"`
+	Activate *bool    `json:"activate,omitempty" yaml:"activate,omitempty"`
+}
+
+func (ts *TaskSpec) SetName(name string) *TaskSpec { ts.Name = name; return ts }
+func (ts *TaskSpec) SetStepback(shouldStepback bool) *TaskSpec {
+	ts.Stepback = shouldStepback
+	return ts
+}
+func (ts *TaskSpec) SetDistros(distros []string) *TaskSpec { ts.Distro = distros; return ts }
+func (ts *TaskSpec) SetActivate(shouldActivate bool) *TaskSpec {
+	ts.Activate = &shouldActivate
+	return ts
 }
 
 func (v *Variant) Name(id string) *Variant                         { v.BuildName = id; return v }

--- a/variant_test.go
+++ b/variant_test.go
@@ -1,6 +1,8 @@
 package shrub
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestVariantBuilders(t *testing.T) {
 	cases := map[string]func(*testing.T, *Variant){
@@ -19,7 +21,7 @@ func TestVariantBuilders(t *testing.T) {
 		"BatchTimeSetter": func(t *testing.T, v *Variant) {
 			assert(t, v.BatchTimeSecs == 0, "default value")
 			v2 := v.BatchTime(12)
-			assert(t, v.BatchTimeSecs == 12, "exected value")
+			assert(t, v.BatchTimeSecs == 12, "expected value")
 			assert(t, v2 == v, "chainable")
 		},
 		"CronBatchTimeSetter": func(t *testing.T, v *Variant) {
@@ -147,6 +149,44 @@ func TestVariantBuilders(t *testing.T) {
 		v := &Variant{}
 		t.Run(name, func(t *testing.T) {
 			test(t, v)
+		})
+	}
+}
+
+func TestTaskSpecBuilders(t *testing.T) {
+	cases := map[string]func(*testing.T, *TaskSpec){
+		"NameSetter": func(t *testing.T, ts *TaskSpec) {
+			assert(t, ts.Name == "", "default value")
+			ts2 := ts.SetName("foo")
+			assert(t, ts.Name == "foo", "expected value")
+			assert(t, ts2 == ts, "chainable")
+		},
+		"StepbackSetter": func(t *testing.T, ts *TaskSpec) {
+			assert(t, ts.Stepback == false, "default value")
+			ts2 := ts.SetStepback(true)
+			assert(t, ts.Stepback, "expected value")
+			assert(t, ts2 == ts, "chainable")
+		},
+		"DistroSetter": func(t *testing.T, ts *TaskSpec) {
+			assert(t, len(ts.Distro) == 0, "default value")
+			ts2 := ts.SetDistros([]string{"distro"})
+			require(t, len(ts.Distro) == 1, "state impacted")
+			assert(t, ts.Distro[0] == "distro", "expected value")
+			assert(t, ts2 == ts, "chainable")
+		},
+		"ActivateSetter": func(t *testing.T, ts *TaskSpec) {
+			assert(t, ts.Activate == nil, "default value")
+			ts2 := ts.SetActivate(true)
+			require(t, ts.Activate != nil)
+			assert(t, *ts.Activate, "expected value")
+			assert(t, ts2 == ts, "chainable")
+		},
+	}
+
+	for name, test := range cases {
+		ts := &TaskSpec{}
+		t.Run(name, func(t *testing.T) {
+			test(t, ts)
 		})
 	}
 }

--- a/variant_test.go
+++ b/variant_test.go
@@ -176,7 +176,7 @@ func TestTaskSpecBuilders(t *testing.T) {
 		},
 		"ActivateSetter": func(t *testing.T, ts *TaskSpec) {
 			assert(t, ts.Activate == nil, "default value")
-			ts2 := ts.SetActivate(true)
+			ts2 := ts.SetActivate(&trueVal)
 			require(t, ts.Activate != nil)
 			assert(t, *ts.Activate, "expected value")
 			assert(t, ts2 == ts, "chainable")


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-19050

* Add some missing fields to task `depends_on` specifications and build variant list of tasks.
* Fix a bug where if a `depends_on` variant was empty, it would have an empty string in the generated JSON, which ended up producing an invalid projcet config during generate.tasks.