### PR TITLE
EVG-20778: variant.go: add Module builder command

### DIFF
--- a/variant.go
+++ b/variant.go
@@ -10,6 +10,7 @@ type Variant struct {
 	DistroRunOn      []string                `json:"run_on,omitempty" yaml:"run_on,omitempty"`
 	Expansions       map[string]interface{}  `json:"expansions,omitempty" yaml:"expansions,omitempty"`
 	DisplayTaskSpecs []DisplayTaskDefinition `json:"display_tasks,omitempty" yaml:"display_tasks,omitempty"`
+	Modules          []string                `json:"modules,omitempty" yaml:"modules,omitempty"`
 	// If Activate is set to false, then we don't initially activate the build variant.
 	Activate       *bool `json:"activate,omitempty" yaml:"activate,omitempty"`
 	Disable        *bool `json:"disable,omitempty" yaml:"disable,omitempty"`
@@ -55,6 +56,7 @@ func (v *Variant) SetGitTagOnly(gitTagOnly *bool) *Variant         { v.GitTagOnl
 func (v *Variant) DisplayName(id string) *Variant                  { v.BuildDisplayName = id; return v }
 func (v *Variant) RunOn(distro string) *Variant                    { v.DistroRunOn = []string{distro}; return v }
 func (v *Variant) TaskSpec(spec TaskSpec) *Variant                 { v.TaskSpecs = append(v.TaskSpecs, spec); return v }
+func (v *Variant) Module(module string) *Variant                   { v.Modules = append(v.Modules, module); return v }
 func (v *Variant) SetExpansions(m map[string]interface{}) *Variant { v.Expansions = m; return v }
 
 func (v *Variant) Expansion(k string, val interface{}) *Variant {

--- a/variant_test.go
+++ b/variant_test.go
@@ -106,7 +106,7 @@ func TestVariantBuilders(t *testing.T) {
 			assert(t, v2 == v, "chainable")
 			assert(t, len(v.Modules) == 1, "state impacted")
 		},
-		"ModuleMutipleTimes": func(t *testing.T, v *Variant) {
+		"ModuleMultipleTimes": func(t *testing.T, v *Variant) {
 			assert(t, len(v.Modules) == 0, "default value")
 			v2 := v.Module("one").Module("two")
 			assert(t, v2 == v, "chainable")

--- a/variant_test.go
+++ b/variant_test.go
@@ -100,6 +100,19 @@ func TestVariantBuilders(t *testing.T) {
 			assert(t, v.DistroRunOn[0] == "baz", "expected value")
 			assert(t, v2 == v, "chainable")
 		},
+		"ModuleSetter": func(t *testing.T, v *Variant) {
+			assert(t, len(v.Modules) == 0, "default value")
+			v2 := v.Module("one")
+			assert(t, v2 == v, "chainable")
+			assert(t, len(v.Modules) == 1, "state impacted")
+		},
+		"ModuleMutipleTimes": func(t *testing.T, v *Variant) {
+			assert(t, len(v.Modules) == 0, "default value")
+			v2 := v.Module("one").Module("two")
+			assert(t, v2 == v, "chainable")
+			require(t, len(v.Modules) == 2, "state impacted")
+			assert(t, v.Modules[1] == "two", "expected value")
+		},
 		"TaskSpecSetterFirst": func(t *testing.T, v *Variant) {
 			v2 := v.TaskSpec(TaskSpec{Name: "foo"})
 			require(t, len(v.TaskSpecs) == 1, "set")


### PR DESCRIPTION
We want to use this internally, and the Variant type is missing a Module command. We could wrap the Variant and the Configuration types, but this seems easy enough to upstream!