### PR TITLE
DEVPROD-991: add missing fields from project YAML to shrub

### DIFF
--- a/task.go
+++ b/task.go
@@ -6,6 +6,7 @@ type Task struct {
 	Dependencies       []TaskDependency `json:"depends_on,omitempty" yaml:"dependencies,omitempty"`
 	Commands           CommandSequence  `json:"commands" yaml:"commands"`
 	Tags               []string         `json:"tags,omitempty" yaml:"tags,omitempty"`
+	DistroRunOn        []string         `json:"run_on,omitempty" yaml:"run_on,omitempty"`
 	PriorityOverride   int              `json:"priority,omitempty" yaml:"priority_override,omitempty"`
 	ExecTimeoutSecs    int              `json:"exec_timeout_secs,omitempty" yaml:"exec_timeout_secs,omitempty"`
 	IsPatchable        *bool            `json:"patchable,omitempty" yaml:"patchable,omitempty"`
@@ -13,14 +14,17 @@ type Task struct {
 	IsAllowedForGitTag *bool            `json:"allow_for_git_tag,omitempty" yaml:"allow_for_git_tag,omitempty"`
 	IsGitTagOnly       *bool            `json:"git_tag_only,omitempty" yaml:"git_tag_only,omitempty"`
 	AllowedRequesters  []string         `json:"allowed_requesters,omitempty" yaml:"allowed_requesters,omitempty"`
+	Disable            *bool            `json:"disable,omitempty" yaml:"disable,omitempty"`
 	CanStepback        *bool            `json:"stepback,omitempty" yaml:"stepback,omitempty"`
 	MustHaveResults    *bool            `json:"must_have_test_results,omitempty" yaml:"must_have_test_results,omitempty"`
 }
 
 type TaskDependency struct {
-	Name    string `json:"name" yaml:"name"`
-	Variant string `json:"variant,omitempty" yaml:"variant,omitempty"`
-	Status  string `json:"status,omitempty" yaml:"status,omitempty"`
+	Name               string `json:"name" yaml:"name"`
+	Variant            string `json:"variant,omitempty" yaml:"variant,omitempty"`
+	Status             string `json:"status,omitempty" yaml:"status,omitempty"`
+	PatchOptional      *bool  `json:"patch_optional,omitempty" yaml:"patch_optional,omitempty"`
+	OmitGeneratedTasks *bool  `json:"omit_generated_tasks,omitempty" yaml:"omit_generated_tasks,omitempty"`
 }
 
 func (td *TaskDependency) SetName(name string) *TaskDependency {
@@ -35,6 +39,16 @@ func (td *TaskDependency) SetVariant(variant string) *TaskDependency {
 
 func (td *TaskDependency) SetStatus(status string) *TaskDependency {
 	td.Status = status
+	return td
+}
+
+func (td *TaskDependency) SetPatchOptional(val bool) *TaskDependency {
+	td.PatchOptional = &val
+	return td
+}
+
+func (td *TaskDependency) SetOmitGeneratedTasks(val bool) *TaskDependency {
+	td.OmitGeneratedTasks = &val
 	return td
 }
 
@@ -73,6 +87,11 @@ func (t *Task) Function(fns ...string) *Task {
 
 func (t *Task) Tag(tags ...string) *Task {
 	t.Tags = append(t.Tags, tags...)
+	return t
+}
+
+func (t *Task) RunOn(distro ...string) *Task {
+	t.DistroRunOn = distro
 	return t
 }
 
@@ -132,18 +151,24 @@ func (t *Task) MustHaveTestResults(val bool) *Task {
 
 // TaskGroup represents a new task group definition.
 type TaskGroup struct {
-	GroupName             string          `json:"name" yaml:"name"`
-	MaxHosts              int             `json:"max_hosts,omitempty" yaml:"max_hosts,omitempty"`
-	ShareProcesses        bool            `json:"share_processes,omitempty" yaml:"share_processes,omitempty"`
-	SetupGroup            CommandSequence `json:"setup_group,omitempty" yaml:"setup_group,omitempty"`
-	SetupGroupCanFailTask bool            `json:"setup_group_can_fail_task,omitempty" yaml:"setup_group_can_fail_task,omitempty"`
-	SetupGroupTimeoutSecs int             `json:"setup_group_timeout_secs,omitempty" yaml:"setup_group_timeout_secs,omitempty"`
-	SetupTask             CommandSequence `json:"setup_task,omitempty" yaml:"setup_task,omitempty"`
-	Tasks                 []string        `json:"tasks" yaml:"tasks"`
-	Tags                  []string        `json:"tags,omitempty" yaml:"tags,omitempty"`
-	TeardownTask          CommandSequence `json:"teardown_task,omitempty" yaml:"teardown_task,omitempty"`
-	TeardownGroup         CommandSequence `json:"teardown_group,omitempty" yaml:"teardown_group,omitempty"`
-	Timeout               CommandSequence `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	GroupName                string          `json:"name" yaml:"name"`
+	MaxHosts                 int             `json:"max_hosts,omitempty" yaml:"max_hosts,omitempty"`
+	ShareProcesses           bool            `json:"share_processes,omitempty" yaml:"share_processes,omitempty"`
+	SetupGroup               CommandSequence `json:"setup_group,omitempty" yaml:"setup_group,omitempty"`
+	SetupGroupCanFailTask    bool            `json:"setup_group_can_fail_task,omitempty" yaml:"setup_group_can_fail_task,omitempty"`
+	SetupGroupTimeoutSecs    int             `json:"setup_group_timeout_secs,omitempty" yaml:"setup_group_timeout_secs,omitempty"`
+	SetupTask                CommandSequence `json:"setup_task,omitempty" yaml:"setup_task,omitempty"`
+	SetupTaskCanFailTask     bool            `json:"setup_task_can_fail_task,omitempty" yaml:"setup_task_can_fail_task,omitempty"`
+	SetupTaskTimeoutSecs     int             `json:"setup_task_timeout_secs,omitempty" yaml:"setup_task_timeout_secs,omitempty"`
+	Tasks                    []string        `json:"tasks" yaml:"tasks"`
+	Tags                     []string        `json:"tags,omitempty" yaml:"tags,omitempty"`
+	TeardownTask             CommandSequence `json:"teardown_task,omitempty" yaml:"teardown_task,omitempty"`
+	TeardownTaskCanFailTask  bool            `json:"teardown_task_can_fail_task,omitempty" yaml:"teardown_task_can_fail_task,omitempty"`
+	TeardownTaskTimeoutSecs  int             `json:"teardown_task_timeout_secs,omitempty" yaml:"teardown_task_timeout_secs,omitempty"`
+	TeardownGroup            CommandSequence `json:"teardown_group,omitempty" yaml:"teardown_group,omitempty"`
+	TeardownGroupTimeoutSecs int             `json:"teardown_group_timeout_secs,omitempty" yaml:"teardown_group_timeout_secs,omitempty"`
+	Timeout                  CommandSequence `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	CallbackTimeoutSecs      int             `json:"callback_timeout_secs,omitempty" yaml:"callback_timeout_secs,omitempty"`
 }
 
 func (g *TaskGroup) Name(id string) *TaskGroup {
@@ -191,6 +216,16 @@ func (g *TaskGroup) SetupTaskCommand(cmds ...Command) *TaskGroup {
 	return g
 }
 
+func (g *TaskGroup) SetSetupTaskCanFailTask(val bool) *TaskGroup {
+	g.SetupTaskCanFailTask = val
+	return g
+}
+
+func (g *TaskGroup) SetSetupTaskTimeoutSecs(timeoutSecs int) *TaskGroup {
+	g.SetupTaskTimeoutSecs = timeoutSecs
+	return g
+}
+
 func (g *TaskGroup) Task(id ...string) *TaskGroup {
 	g.Tasks = append(g.Tasks, id...)
 	return g
@@ -206,6 +241,16 @@ func (g *TaskGroup) TeardownTaskCommand(cmds ...Command) *TaskGroup {
 	return g
 }
 
+func (g *TaskGroup) SetTeardownTaskCanFailTask(val bool) *TaskGroup {
+	g.TeardownTaskCanFailTask = val
+	return g
+}
+
+func (g *TaskGroup) SetTeardownTaskTimeoutSecs(timeoutSecs int) *TaskGroup {
+	g.TeardownTaskTimeoutSecs = timeoutSecs
+	return g
+}
+
 func (g *TaskGroup) TeardownGroupCommand(cmds ...Command) *TaskGroup {
 	for _, c := range cmds {
 		if err := c.Validate(); err != nil {
@@ -216,6 +261,11 @@ func (g *TaskGroup) TeardownGroupCommand(cmds ...Command) *TaskGroup {
 	return g
 }
 
+func (g *TaskGroup) SetTeardownGroupTimeoutSecs(timeoutSecs int) *TaskGroup {
+	g.TeardownGroupTimeoutSecs = timeoutSecs
+	return g
+}
+
 func (g *TaskGroup) TimeoutCommand(cmds ...Command) *TaskGroup {
 	for _, c := range cmds {
 		if err := c.Validate(); err != nil {
@@ -223,6 +273,11 @@ func (g *TaskGroup) TimeoutCommand(cmds ...Command) *TaskGroup {
 		}
 		g.Timeout = append(g.Timeout, c.Resolve())
 	}
+	return g
+}
+
+func (g *TaskGroup) SetCallbackTimeoutSecs(timeoutSecs int) *TaskGroup {
+	g.CallbackTimeoutSecs = timeoutSecs
 	return g
 }
 

--- a/variant.go
+++ b/variant.go
@@ -4,6 +4,7 @@ package shrub
 type Variant struct {
 	BuildName        string                  `json:"name,omitempty" yaml:"name,omitempty"`
 	BuildDisplayName string                  `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Tags             []string                `json:"tags,omitempty" yaml:"omitempty"`
 	BatchTimeSecs    int                     `json:"batchtime,omitempty" yaml:"batchtime,omitempty"`
 	CronBatchTime    string                  `json:"cron,omitempty" yaml:"cron,omitempty"`
 	Stepback         *bool                   `json:"stepback,omitempty" yaml:"stepback,omitempty"`
@@ -12,6 +13,7 @@ type Variant struct {
 	Expansions       map[string]interface{}  `json:"expansions,omitempty" yaml:"expansions,omitempty"`
 	DisplayTaskSpecs []DisplayTaskDefinition `json:"display_tasks,omitempty" yaml:"display_tasks,omitempty"`
 	Modules          []string                `json:"modules,omitempty" yaml:"modules,omitempty"`
+	DependsOn        []TaskDependency        `json:"depends_on,omitempty" yaml:"depends_on,omitempty"`
 	// If Activate is set to false, then we don't initially activate the build variant.
 	Activate          *bool    `json:"activate,omitempty" yaml:"activate,omitempty"`
 	Disable           *bool    `json:"disable,omitempty" yaml:"disable,omitempty"`
@@ -28,16 +30,33 @@ type DisplayTaskDefinition struct {
 }
 
 type TaskSpec struct {
-	Name              string   `json:"name" yaml:"name"`
-	Stepback          bool     `json:"stepback,omitempty" yaml:"stepback,omitempty"`
+	Name     string `json:"name" yaml:"name"`
+	Stepback bool   `json:"stepback,omitempty" yaml:"stepback,omitempty"`
+	// Distro is deprecated in favor of RunOn.
 	Distro            []string `json:"distros,omitempty" yaml:"distro,omitempty"`
-	Activate          *bool    `json:"activate,omitempty" yaml:"activate,omitempty"`
-	Disable           *bool    `json:"disable,omitempty" yaml:"disable,omitempty"`
-	Patchable         *bool    `json:"patchable,omitempty" yaml:"patchable,omitempty"`
-	PatchOnly         *bool    `json:"patch_only,omitempty" yaml:"patch_only,omitempty"`
-	AllowForGitTag    *bool    `json:"allow_for_git_tag,omitempty" yaml:"allow_for_git_tag,omitempty"`
-	GitTagOnly        *bool    `json:"git_tag_only,omitempty" yaml:"git_tag_only,omitempty"`
-	AllowedRequesters []string `json:"allowed_requesters,omitempty" yaml:"allowed_requesters,omitempty"`
+	RunOn             []string `json:"run_on,omitempty" yaml:"run_on,omitempty"`
+	Priority          int      `json:"priority,omitempty" yaml:"priority,omitempty"`
+	ExecTimeoutSecs   int      `json:"exec_timeout_secs,omitempty" yaml:"exec_timeout_secs,omitempty"`
+	Batchtime         int      `json:"batchtime,omitempty" yaml:"batchtime,omitempty"`
+	CronBatchtime     string
+	Activate          *bool      `json:"activate,omitempty" yaml:"activate,omitempty"`
+	Disable           *bool      `json:"disable,omitempty" yaml:"disable,omitempty"`
+	Patchable         *bool      `json:"patchable,omitempty" yaml:"patchable,omitempty"`
+	PatchOnly         *bool      `json:"patch_only,omitempty" yaml:"patch_only,omitempty"`
+	AllowForGitTag    *bool      `json:"allow_for_git_tag,omitempty" yaml:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool      `json:"git_tag_only,omitempty" yaml:"git_tag_only,omitempty"`
+	AllowedRequesters []string   `json:"allowed_requesters,omitempty" yaml:"allowed_requesters,omitempty"`
+	TaskGroup         *TaskGroup `json:"task_group,omitempty" yaml:"task_group,omitempty"`
+	CreateCheckRun    *CheckRun  `json:"create_check_run,omitempty" yaml:"create_check_run,omitempty"`
+}
+
+type CheckRun struct {
+	PathToOutputs string `json:"path_to_outputs,omitempty" yaml:"path_to_outputs,omitempty"`
+}
+
+func (cr *CheckRun) SetPathToOutputs(path string) *CheckRun {
+	cr.PathToOutputs = path
+	return cr
 }
 
 func (ts *TaskSpec) SetName(name string) *TaskSpec { ts.Name = name; return ts }
@@ -45,7 +64,45 @@ func (ts *TaskSpec) SetStepback(shouldStepback bool) *TaskSpec {
 	ts.Stepback = shouldStepback
 	return ts
 }
+
+// SetDistros is deprecated in favor of RunOn.
 func (ts *TaskSpec) SetDistros(distros []string) *TaskSpec { ts.Distro = distros; return ts }
+
+func (ts *TaskSpec) SetRunOn(distros ...string) *TaskSpec {
+	ts.RunOn = distros
+	return ts
+}
+
+func (ts *TaskSpec) SetPriority(priority int) *TaskSpec {
+	ts.Priority = priority
+	return ts
+}
+
+func (ts *TaskSpec) SetExecTimeoutSecs(timeoutSecs int) *TaskSpec {
+	ts.ExecTimeoutSecs = timeoutSecs
+	return ts
+}
+
+func (ts *TaskSpec) SetBatchtime(batchtime int) *TaskSpec {
+	ts.Batchtime = batchtime
+	return ts
+}
+
+func (ts *TaskSpec) SetCronBatchtime(cron string) *TaskSpec {
+	ts.CronBatchtime = cron
+	return ts
+}
+
+func (ts *TaskSpec) SetTaskGroup(tg TaskGroup) *TaskSpec {
+	ts.TaskGroup = &tg
+	return ts
+}
+
+func (ts *TaskSpec) SetCreateCheckrun(checkRun CheckRun) *TaskSpec {
+	ts.CreateCheckRun = &checkRun
+	return ts
+}
+
 func (ts *TaskSpec) SetActivate(shouldActivate *bool) *TaskSpec {
 	ts.Activate = shouldActivate
 	return ts
@@ -81,7 +138,11 @@ func (ts *TaskSpec) AllowedRequester(requesters ...string) *TaskSpec {
 	return ts
 }
 
-func (v *Variant) Name(id string) *Variant                    { v.BuildName = id; return v }
+func (v *Variant) Name(id string) *Variant { v.BuildName = id; return v }
+func (v *Variant) SetTags(tags ...string) *Variant {
+	v.Tags = tags
+	return v
+}
 func (v *Variant) BatchTime(batchTimeSecs int) *Variant       { v.BatchTimeSecs = batchTimeSecs; return v }
 func (v *Variant) SetCronBatchTime(batchTime string) *Variant { v.CronBatchTime = batchTime; return v }
 func (v *Variant) SetStepback(stepback *bool) *Variant        { v.Stepback = stepback; return v }
@@ -96,10 +157,14 @@ func (v *Variant) AllowedRequester(requesters ...string) *Variant {
 	return v
 }
 
-func (v *Variant) DisplayName(id string) *Variant                  { v.BuildDisplayName = id; return v }
-func (v *Variant) RunOn(distro string) *Variant                    { v.DistroRunOn = []string{distro}; return v }
-func (v *Variant) TaskSpec(spec TaskSpec) *Variant                 { v.TaskSpecs = append(v.TaskSpecs, spec); return v }
-func (v *Variant) Module(module string) *Variant                   { v.Modules = append(v.Modules, module); return v }
+func (v *Variant) DisplayName(id string) *Variant  { v.BuildDisplayName = id; return v }
+func (v *Variant) RunOn(distro string) *Variant    { v.DistroRunOn = []string{distro}; return v }
+func (v *Variant) TaskSpec(spec TaskSpec) *Variant { v.TaskSpecs = append(v.TaskSpecs, spec); return v }
+func (v *Variant) Module(module string) *Variant   { v.Modules = append(v.Modules, module); return v }
+func (v *Variant) SetDependsOn(deps ...TaskDependency) *Variant {
+	v.DependsOn = deps
+	return v
+}
 func (v *Variant) SetExpansions(m map[string]interface{}) *Variant { v.Expansions = m; return v }
 
 func (v *Variant) Expansion(k string, val interface{}) *Variant {


### PR DESCRIPTION
[DEVPROD-991](https://jira.mongodb.org/browse/DEVPROD-991)

I filled in all the missing fields from the parser project that can be set in generate.tasks.

Ran tests locally and they pass + have 100% statement coverage.