### PR TITLE
DEVPROD-2281: support add_to_path in shell.exec

### DIFF
--- a/operations.go
+++ b/operations.go
@@ -61,6 +61,7 @@ type CmdExecShell struct {
 	Env                           map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	AddExpansionsToEnv            map[string]string `json:"add_expansions_to_env,omitempty" yaml:"add_expansions_to_env,omitempty"`
 	IncludeExpansionsInEnv        map[string]string `json:"include_expansions_in_env,omitempty" yaml:"include_expansions_inenv,omitempty"`
+	AddToPath                     []string          `json:"add_to_path,omitempty" yaml:"add_to_path,omitempty"`
 	ContinueOnError               bool              `json:"continue_on_err,omitempty" yaml:"continue_on_err,omitempty"`
 	Background                    bool              `json:"background,omitempty" yaml:"background,omitempty"`
 	Silent                        bool              `json:"silent,omitempty" yaml:"silent,omitempty"`


### PR DESCRIPTION
Follow-on to https://github.com/evergreen-ci/evergreen/pull/7858 to add the new shell.exec `add_to_path` parameter for generating tasks.