### PR TITLE
DEVPROD-5122: add support for command-level failure metadata tags

### DIFF
--- a/command.go
+++ b/command.go
@@ -61,15 +61,16 @@ type commandRegistry struct {
 type commandFactory func() Command
 
 type CommandDefinition struct {
-	FunctionName   string                 `json:"func,omitempty" yaml:"function_name,omitempty"`
-	ExecutionType  string                 `json:"type,omitempty" yaml:"type,omitempty"`
-	DisplayName    string                 `json:"display_name,omitempty" yaml:"display_name,omitempty"`
-	CommandName    string                 `json:"command,omitempty" yaml:"command,omitempty"`
-	RunVariants    []string               `json:"variants,omitempty" yaml:"variants,omitempty"`
-	TimeoutSecs    int                    `json:"timeout_secs,omitempty" yaml:"timeout_secs,omitempty"`
-	RetryOnFailure bool                   `json:"retry_on_failure,omitempty" yaml:"retry_on_failure,omitempty"`
-	Params         map[string]interface{} `json:"params,omitempty" yaml:"params,omitempty"`
-	Vars           map[string]string      `json:"vars,omitempty" yaml:"vars,omitempty"`
+	FunctionName        string                 `json:"func,omitempty" yaml:"function_name,omitempty"`
+	ExecutionType       string                 `json:"type,omitempty" yaml:"type,omitempty"`
+	DisplayName         string                 `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	CommandName         string                 `json:"command,omitempty" yaml:"command,omitempty"`
+	RunVariants         []string               `json:"variants,omitempty" yaml:"variants,omitempty"`
+	TimeoutSecs         int                    `json:"timeout_secs,omitempty" yaml:"timeout_secs,omitempty"`
+	RetryOnFailure      bool                   `json:"retry_on_failure,omitempty" yaml:"retry_on_failure,omitempty"`
+	FailureMetadataTags []string               `json:"failure_metadata_tags,omitempty" yaml:"failure_metadata_tags,omitempty"`
+	Params              map[string]interface{} `json:"params,omitempty" yaml:"params,omitempty"`
+	Vars                map[string]string      `json:"vars,omitempty" yaml:"vars,omitempty"`
 }
 
 func (c *CommandDefinition) Validate() error                      { return nil }


### PR DESCRIPTION
Add the new command configuration from https://github.com/evergreen-ci/evergreen/pull/7880.