### PR TITLE
DEVPROD-16091 Fix more JSON and YAML struct tags

### DIFF
--- a/command.go
+++ b/command.go
@@ -62,7 +62,7 @@ type commandRegistry struct {
 type commandFactory func() Command
 
 type CommandDefinition struct {
-	FunctionName        string                 `json:"func,omitempty" yaml:"function_name,omitempty"`
+	FunctionName        string                 `json:"func,omitempty" yaml:"func,omitempty"`
 	ExecutionType       string                 `json:"type,omitempty" yaml:"type,omitempty"`
 	DisplayName         string                 `json:"display_name,omitempty" yaml:"display_name,omitempty"`
 	CommandName         string                 `json:"command,omitempty" yaml:"command,omitempty"`

--- a/operations.go
+++ b/operations.go
@@ -68,8 +68,8 @@ type CmdExecShell struct {
 	Background                    bool              `json:"background,omitempty" yaml:"background,omitempty"`
 	Silent                        bool              `json:"silent,omitempty" yaml:"silent,omitempty"`
 	RedirectStandardErrorToOutput bool              `json:"redirect_standard_error_to_output,omitempty" yaml:"redirect_standard_error_to_output,omitempty"`
-	IgnoreStandardError           bool              `json:"ignore_standard_error" yaml:"ignore_standard_error"`
-	IgnoreStandardOutput          bool              `json:"ignore_standard_out" yaml:"ignore_standard_out"`
+	IgnoreStandardError           bool              `json:"ignore_standard_error,omitempty" yaml:"ignore_standard_error,omitempty"`
+	IgnoreStandardOutput          bool              `json:"ignore_standard_out,omitempty" yaml:"ignore_standard_out,omitempty"`
 	SystemLog                     bool              `json:"system_log,omitempty" yaml:"system_log,omitempty"`
 	WorkingDirectory              string            `json:"working_dir,omitempty" yaml:"working_dir,omitempty"`
 }

--- a/task.go
+++ b/task.go
@@ -3,7 +3,7 @@ package shrub
 // Task represents a single new task to generate.
 type Task struct {
 	Name               string           `json:"name" yaml:"name"`
-	Dependencies       []TaskDependency `json:"depends_on,omitempty" yaml:"dependencies,omitempty"`
+	Dependencies       []TaskDependency `json:"depends_on,omitempty" yaml:"depends_on,omitempty"`
 	Commands           CommandSequence  `json:"commands" yaml:"commands"`
 	Tags               []string         `json:"tags,omitempty" yaml:"tags,omitempty"`
 	DistroRunOn        []string         `json:"run_on,omitempty" yaml:"run_on,omitempty"`


### PR DESCRIPTION
The `CommandDefinition.FunctionName` field had the wrong YAML field name. It should be `func`, not `function`.

The `Task.Dependencies` YAML struct tag also had the wrong field name. It should be `depends_on`, not `dependencies.

The `CmdExecShell` struct's `IgnoreStandardError` and `IgnoreStandardOutput` fields were missing `omitempty` in their JSON and YAML tags.

