### PR TITLE
DEVPROD-17440 Add missing fields to the `CmdS3Get` and `CmdS3Put` structs

### DIFF
--- a/operations.go
+++ b/operations.go
@@ -101,6 +101,7 @@ type CmdS3Put struct {
 	ResourceDisplayName           string   `json:"display_name,omitempty" yaml:"display_name,omitempty"`
 	BuildVariants                 []string `json:"build_variants,omitempty" yaml:"build_variants,omitempty"`
 	Optional                      bool     `json:"optional,omitempty" yaml:"optional,omitempty"`
+	SkipExisting                  bool     `json:"skip_existing,omitempty" yaml:"skip_existing,omitempty"`
 }
 
 func (c CmdS3Put) Name() string { return "s3.put" }

--- a/operations.go
+++ b/operations.go
@@ -132,6 +132,7 @@ type CmdS3Get struct {
 	LocalFile       string   `json:"local_file,omitempty" yaml:"local_file,omitempty"`
 	ExtractTo       string   `json:"extract_to,omitempty" yaml:"extract_to,omitempty"`
 	BuildVariants   []string `json:"build_variants,omitempty" yaml:"build_variants,omitempty"`
+	Optional        bool     `json:"optional,omitempty" yaml:"optional,omitempty"`
 }
 
 func (c CmdS3Get) Name() string    { return "s3.get" }

--- a/operations.go
+++ b/operations.go
@@ -102,6 +102,7 @@ type CmdS3Put struct {
 	BuildVariants                 []string `json:"build_variants,omitempty" yaml:"build_variants,omitempty"`
 	Optional                      bool     `json:"optional,omitempty" yaml:"optional,omitempty"`
 	SkipExisting                  bool     `json:"skip_existing,omitempty" yaml:"skip_existing,omitempty"`
+	RoleARN                       string   `json:"role_arn,omitempty" yaml:"role_arn,omitempty"`
 }
 
 func (c CmdS3Put) Name() string { return "s3.put" }
@@ -134,6 +135,7 @@ type CmdS3Get struct {
 	ExtractTo       string   `json:"extract_to,omitempty" yaml:"extract_to,omitempty"`
 	BuildVariants   []string `json:"build_variants,omitempty" yaml:"build_variants,omitempty"`
 	Optional        bool     `json:"optional,omitempty" yaml:"optional,omitempty"`
+	RoleARN         string   `json:"role_arn,omitempty" yaml:"role_arn,omitempty"`
 }
 
 func (c CmdS3Get) Name() string    { return "s3.get" }


### PR DESCRIPTION
This adds `CmdS3Get.Optional` and `CmdS3Put.SkipExisting`, as well as adding the `RoleARN` field to both S3 commands.